### PR TITLE
Duplicate compile dependency

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -29,7 +29,6 @@ repositories {
 
 dependencies {
     compile('org.springframework.boot:spring-boot-starter-webflux')
-    compile('org.springframework.boot:spring-boot-starter-webflux')
     testCompile('org.springframework.boot:spring-boot-starter-test')
 }
 


### PR DESCRIPTION
```groovy
    compile('org.springframework.boot:spring-boot-starter-webflux')
```